### PR TITLE
Fixes #7501: Fixing timezone for Beiging

### DIFF
--- a/techniques/systemSettings/misc/clockConfiguration/3.0/clockConfiguration.st
+++ b/techniques/systemSettings/misc/clockConfiguration/3.0/clockConfiguration.st
@@ -118,7 +118,7 @@ bundle agent check_clock_configuration
 
     clock_set_beijing::
 
-      "linux_timezone" string => "Europe/Paris";
+      "linux_timezone" string => "Asia/Shanghai";
       "windows_timezone" string => "China Standard Time";
 
   classes:


### PR DESCRIPTION
Technique clockConfiguration v3.0 sets TZ of Beijing to Paris again.
